### PR TITLE
Ensure test Make target gets run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ clean: ## Cleanup downloaded files and packages
 	rm zarf-uploader/packages/npm/*
 	rm zarf-package-dev-dependencies-amd64.tar.zst
 
+.PHONY: test
 test: ## Test an already deployed version of the package
 	./test/run.sh
 


### PR DESCRIPTION
I noticed that the last few workflow runs did not execute the `test` make-target. I added the `.PHONY` label to the target so that make will actually execute the commands.


I was exploring the repository and was having issues utilizing the PyPi packages that were published to Gitea. When I added the `.PHONY` and re-ran this test it failed locally. There might be a bug that needs to be corrected but the first step was to see if the test also fails when running in the pipeline.